### PR TITLE
Helm chart for EKS deployment

### DIFF
--- a/helm/notificationservice/Chart.yaml
+++ b/helm/notificationservice/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: notificationservice
+description: Helm chart for VibeVault Notification Service
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/helm/notificationservice/templates/NOTES.txt
+++ b/helm/notificationservice/templates/NOTES.txt
@@ -1,0 +1,12 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+To check the status of your deployment:
+
+  kubectl get deployments -n {{ .Release.Namespace }}
+
+To access the notificationservice:
+
+  kubectl port-forward svc/{{ include "notificationservice.fullname" . }} {{ .Values.containerPort }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}

--- a/helm/notificationservice/templates/_helpers.tpl
+++ b/helm/notificationservice/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/*
+Chart name.
+*/}}
+{{- define "notificationservice.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Fullname.
+*/}}
+{{- define "notificationservice.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "notificationservice.labels" -}}
+app: {{ include "notificationservice.name" . }}
+version: v1
+part-of: vibevault
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "notificationservice.selectorLabels" -}}
+app: {{ include "notificationservice.name" . }}
+{{- end }}

--- a/helm/notificationservice/templates/configmap.yaml
+++ b/helm/notificationservice/templates/configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "notificationservice.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "notificationservice.labels" . | nindent 4 }}
+data:
+  PORT: "{{ .Values.containerPort }}"
+  {{- if .Values.config.kafkaBootstrapServers }}
+  KAFKA_BOOTSTRAP_SERVERS: {{ .Values.config.kafkaBootstrapServers | quote }}
+  {{- end }}
+  SES_ENABLED: {{ .Values.config.sesEnabled | quote }}
+  SES_FROM_EMAIL: {{ .Values.config.sesFromEmail | quote }}
+  SES_TO_EMAIL: {{ .Values.config.sesToEmail | quote }}
+  SES_REGION: {{ .Values.config.sesRegion | quote }}

--- a/helm/notificationservice/templates/deployment.yaml
+++ b/helm/notificationservice/templates/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "notificationservice.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "notificationservice.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "notificationservice.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: {{ .Values.strategy.type }}
+    {{- if eq .Values.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxUnavailable: {{ .Values.strategy.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.strategy.rollingUpdate.maxSurge }}
+    {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "notificationservice.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ include "notificationservice.name" . }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.containerPort }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "notificationservice.fullname" . }}-config
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: {{ .Values.containerPort }}
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/helm/notificationservice/templates/service.yaml
+++ b/helm/notificationservice/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "notificationservice.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "notificationservice.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "notificationservice.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.containerPort }}
+      protocol: TCP

--- a/helm/notificationservice/values.yaml
+++ b/helm/notificationservice/values.yaml
@@ -1,0 +1,33 @@
+replicaCount: 1
+
+image:
+  repository: notificationservice
+  tag: latest
+  pullPolicy: Always
+
+containerPort: 8085
+
+service:
+  type: ClusterIP
+  port: 80
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 500m
+    memory: 768Mi
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+    maxSurge: 1
+
+config:
+  kafkaBootstrapServers: ""
+  sesEnabled: "false"
+  sesFromEmail: ""
+  sesToEmail: ""
+  sesRegion: "ap-south-1"


### PR DESCRIPTION
## Summary
- Stateless Kafka consumer — no database, no Flyway, no ExternalSecret
- ConfigMap: PORT, KAFKA_BOOTSTRAP_SERVERS, SES config (enabled/from/to/region)
- Deployment with liveness/readiness probes, port 8085
- 1 replica (single consumer sufficient for notification volume)
- SES credentials via EKS node IAM role in production

## Test plan
- [x] `helm template notificationservice helm/notificationservice/` renders valid YAML

Closes #5